### PR TITLE
Add NuGet package ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "nuget"
+    directory: "/code/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to add automated NuGet dependency updates for the `/code/` directory on a weekly schedule.

Dependency management:

* Added a new entry to `.github/dependabot.yml` to enable weekly NuGet package updates in the `/code/` directory.